### PR TITLE
MatrixResponse results must to result

### DIFF
--- a/src/main/java/com/github/anhdat/models/MatrixResponse.java
+++ b/src/main/java/com/github/anhdat/models/MatrixResponse.java
@@ -9,7 +9,7 @@ public class MatrixResponse {
 
     static class MatrixData {
         String resultType;
-        List<MatrixResult> results;
+        List<MatrixResult> result;
     }
 
     static class MatrixResult {


### PR DESCRIPTION
MatrixResponse results must to result

```
$ curl 'http://localhost:9090/api/v1/query_range?query=up&start=2015-07-01T20:10:30.781Z&end=2015-07-01T20:11:00.781Z&step=15s'
{
   "status" : "success",
   "data" : {
      "resultType" : "matrix",
      "result" : [
         {
            "metric" : {
               "__name__" : "up",
               "job" : "prometheus",
               "instance" : "localhost:9090"
            },
            "values" : [
               [ 1435781430.781, "1" ],
               [ 1435781445.781, "1" ],
               [ 1435781460.781, "1" ]
            ]
         },
         {
            "metric" : {
               "__name__" : "up",
               "job" : "node",
               "instance" : "localhost:9091"
            },
            "values" : [
               [ 1435781430.781, "0" ],
               [ 1435781445.781, "0" ],
               [ 1435781460.781, "1" ]
            ]
         }
      ]
   }
}
```